### PR TITLE
Move JwtVerifier.java to backendServices

### DIFF
--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java
@@ -21,7 +21,7 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.Before;
 import org.junit.Test;
 import it.io.openliberty.guides.jwt.util.TestUtils;
-import test.JwtVerifier;
+import it.io.openliberty.guides.jwt.util.JwtVerifier;
 
 public class InventoryEndpointTest {
 

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java
@@ -20,7 +20,7 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.Test;
 import org.junit.Before;
 import it.io.openliberty.guides.jwt.util.TestUtils;
-import test.JwtVerifier;
+import it.io.openliberty.guides.jwt.util.JwtVerifier;
 
 public class JwtTest {
 

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java
@@ -21,7 +21,7 @@ import javax.ws.rs.core.Response.Status;
 import org.junit.Before;
 import org.junit.Test;
 import it.io.openliberty.guides.jwt.util.TestUtils;
-import test.JwtVerifier;
+import it.io.openliberty.guides.jwt.util.JwtVerifier;
 
 public class SystemEndpointTest {
 

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/util/JwtVerifier.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/util/JwtVerifier.java
@@ -160,6 +160,8 @@ public class JwtVerifier {
         // Open the keystore that the server will use to validate the JWT
         KeyStore ks = KeyStore.getInstance("JCEKS");
         InputStream ksStream = this.getClass().getResourceAsStream(this.keystorePath);
+        assertNotNull("Keystore resource not found!", this.getClass().getResource(JwtVerifier.keystorePath));
+
         char[] password = new String("secret").toCharArray();
         ks.load(ksStream, password);
 

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/util/JwtVerifier.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/util/JwtVerifier.java
@@ -8,7 +8,7 @@
 //  Contributors:
 //  IBM Corporation - initial API and implementation
 // ******************************************************************************
-package test;
+package it.io.openliberty.guides.jwt.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/start/backendServices/src/test/java/it/io/openliberty/guides/jwt/util/JwtVerifier.java
+++ b/start/backendServices/src/test/java/it/io/openliberty/guides/jwt/util/JwtVerifier.java
@@ -8,7 +8,7 @@
 //  Contributors:
 //  IBM Corporation - initial API and implementation
 // ******************************************************************************
-package test;
+package it.io.openliberty.guides.jwt.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -160,6 +160,8 @@ public class JwtVerifier {
         // Open the keystore that the server will use to validate the JWT
         KeyStore ks = KeyStore.getInstance("JCEKS");
         InputStream ksStream = this.getClass().getResourceAsStream(this.keystorePath);
+        assertNotNull("Keystore resource not found!", this.getClass().getResource(JwtVerifier.keystorePath));
+
         char[] password = new String("secret").toCharArray();
         ks.load(ksStream, password);
 


### PR DESCRIPTION
Moved JwtVerifier to the backendServices, adjusted existing test code accordingly, added an extra check to make sure that keystore is loaded.