### PR TITLE
Configured to use loose config

### DIFF
--- a/finish/backendServices/pom.xml
+++ b/finish/backendServices/pom.xml
@@ -177,6 +177,7 @@
                             <appsDirectory>apps</appsDirectory>
                             <stripVersion>true</stripVersion>
                             <installAppPackages>project</installAppPackages>
+                            <looseApplication>true</looseApplication>
                         </configuration>
                     </execution>
                     <execution>

--- a/finish/frontendUI/pom.xml
+++ b/finish/frontendUI/pom.xml
@@ -147,6 +147,7 @@
                             <appsDirectory>apps</appsDirectory>
                             <stripVersion>true</stripVersion>
                             <installAppPackages>project</installAppPackages>
+                            <looseApplication>true</looseApplication>
                         </configuration>
                     </execution>
                     <execution>

--- a/start/backendServices/pom.xml
+++ b/start/backendServices/pom.xml
@@ -177,6 +177,7 @@
                             <appsDirectory>apps</appsDirectory>
                             <stripVersion>true</stripVersion>
                             <installAppPackages>project</installAppPackages>
+                            <looseApplication>true</looseApplication>
                         </configuration>
                     </execution>
                     <execution>

--- a/start/frontendUI/pom.xml
+++ b/start/frontendUI/pom.xml
@@ -147,6 +147,7 @@
                             <appsDirectory>apps</appsDirectory>
                             <stripVersion>true</stripVersion>
                             <installAppPackages>project</installAppPackages>
+                            <looseApplication>true</looseApplication>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
Loose config is necessary to make applications work with `mvn compile`. We should changes all our guides to work with `mvn compile` based on issue https://github.com/OpenLiberty/guides-common/issues/121