### PR TITLE
Redirect to application.jsf after login

### DIFF
--- a/finish/frontendUI/src/main/java/io/openliberty/guides/ui/LoginBean.java
+++ b/finish/frontendUI/src/main/java/io/openliberty/guides/ui/LoginBean.java
@@ -77,7 +77,7 @@ public class LoginBean {
         } else {
             System.out.println("Update Sessional JWT Failed.");
         }
-        return "application.jsf";
+        return "application.jsf?faces-redirect=true";
     }
 
   private String buildJwt(String userName, Set<String> roles) throws Exception {

--- a/start/frontendUI/src/main/java/io/openliberty/guides/ui/LoginBean.java
+++ b/start/frontendUI/src/main/java/io/openliberty/guides/ui/LoginBean.java
@@ -77,7 +77,7 @@ public class LoginBean {
         } else {
             System.out.println("Update Sessional JWT Failed.");
         }
-        return "application.jsf";
+        return "application.jsf?faces-redirect=true";
     }
 
   private String buildJwt(String userName, Set<String> roles) throws Exception {


### PR DESCRIPTION
Address issues #74 and #37 .

The issue seemed to be that if you refreshed the page after login, chrome would ask you to confirm form resubmission. The issue is that the form contained a hidden view state field, and when the form is resubmitted the view state has expired causing the issue. To fix this, I made the page actually redirect to `application.jsf` instead of just displaying what `application.jsf` would display while remaining on `login.jsf`. Now if they refresh the page, it works as expected.
