### PR TITLE
Updating guide formatting

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -139,20 +139,22 @@ The [hotspot=25-26]`<mpJwt/>` element is required to configure the injection of 
 
 [role="code_command hotspot", subs="quotes"]
 ----
-#Replace the `SystemResource` class#
+#Update the `SystemResource` class#
 `backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java`
 ----
+[role="edit_command_text"]
+Add the [hotspot=RolesAllowed]`@RolesAllowed` line.
 
 SystemResource.java
 [source, java, linenums, role='code_column']
 ----
-include::finish/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java[tags=jwt;!copyright]
+include::finish/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java[]
 ----
 
 You have just added roles-based access control to the `SystemResource` class.
 Role names that are used in the [hotspot=15]`@RolesAllowed` annotation are mapped to group names in the `groups` claim of the JWT, which results in an authorization decision wherever the security constraint is applied.
 
-The [hotspot=15]`@RolesAllowed({"admin", "user"})` annotation allows only authenticated users with the role of `admin` or `user` to access the `system` service.
+The [hotspot=RolesAllowed]`@RolesAllowed({"admin", "user"})` annotation allows only authenticated users with the role of `admin` or `user` to access the `system` service.
 Therefore, this service is properly secured.
 
 // =================================================================================================

--- a/README.adoc
+++ b/README.adoc
@@ -114,7 +114,7 @@ The MicroProfile JWT feature, [hotspot=mpJwt]`mpJwt`, has been added as a depend
 ----
 
 server.xml
-[source, xml, linenums, role='code_column hide_tags=Copyright']
+[source, xml, linenums, role='code_column hide_tags=copyright']
 ----
 include::finish/backendServices/src/main/liberty/config/server.xml[]
 ----
@@ -146,7 +146,7 @@ The [hotspot=mpJwtTag]`<mpJwt/>` element is required to configure the injection 
 Add the [hotspot=RolesAllowed]`@RolesAllowed` annotation.
 
 SystemResource.java
-[source, java, linenums, role='code_column hide_tags=Copyright']
+[source, java, linenums, role='code_column hide_tags=copyright']
 ----
 include::finish/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java[]
 ----
@@ -172,7 +172,7 @@ Therefore, this service is properly secured.
 Add the [hotspot=RolesAllowed hotspot=RolesAllowed2]`@RolesAllowed` annotations.
 
 InventoryResource.java
-[source, java, linenums, role='code_column hide_tags=Copyright']
+[source, java, linenums, role='code_column hide_tags=copyright']
 ----
 include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java[]
 ----
@@ -200,7 +200,7 @@ However, after you secure the system service with token-based authentication, yo
 ----
 
 SecureSystemClient.java
-[source, java, linenums, role='code_column hide_tags=Copyright']
+[source, java, linenums, role='code_column hide_tags=copyright']
 ----
 include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/client/SecureSystemClient.java[]
 ----
@@ -226,7 +226,7 @@ To demonstrate how MicroProfile JWT retrieves confidential information and valid
 ----
 
 JwtResource.java
-[source, java, linenums, role='code_column hide_tags=Copyright']
+[source, java, linenums, role='code_column hide_tags=copyright']
 ----
 include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java[]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -286,7 +286,7 @@ Write `SystemEndpointTest`, `InventoryEndpointTest`, and `JwtTest` classes to te
 ----
 
 SystemEndpointTest.java
-[source, java, linenums, role='code_column']
+[source, java, linenums, role='code_column hide_tags=copyright']
 ----
 include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java[]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -114,7 +114,7 @@ The MicroProfile JWT feature, [hotspot=mpJwt]`mpJwt`, has been added as a depend
 ----
 
 server.xml
-[source, xml, linenums, role='code_column']
+[source, xml, linenums, role='code_column hide_tags=Copyright']
 ----
 include::finish/backendServices/src/main/liberty/config/server.xml[]
 ----
@@ -154,7 +154,7 @@ include::finish/backendServices/src/main/java/io/openliberty/guides/system/Syste
 You have just added roles-based access control to the `SystemResource` class.
 Role names that are used in the [hotspot=RolesAllowed]`@RolesAllowed` annotation are mapped to group names in the `groups` claim of the JWT, which results in an authorization decision wherever the security constraint is applied.
 
-The [hotspot=RolesAllowed]`@RolesAllowed` annotation allows only authenticated users with the role of `admin` or `user` to access the `system` service.
+The [hotspot=RolesAllowed]`@RolesAllowed({"admin", "user"})` annotation allows only authenticated users with the role of `admin` or `user` to access the `system` service.
 Therefore, this service is properly secured.
 
 // =================================================================================================

--- a/README.adoc
+++ b/README.adoc
@@ -143,7 +143,7 @@ The [hotspot=mpJwtTag]`<mpJwt/>` element is required to configure the injection 
 `backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java`
 ----
 [role="edit_command_text"]
-Add the [hotspot=RolesAllowed]`@RolesAllowed({"admin", "user"})` annotation.
+Add the [hotspot=RolesAllowed]`@RolesAllowed` annotation.
 
 SystemResource.java
 [source, java, linenums, role='code_column']
@@ -154,7 +154,7 @@ include::finish/backendServices/src/main/java/io/openliberty/guides/system/Syste
 You have just added roles-based access control to the `SystemResource` class.
 Role names that are used in the [hotspot=RolesAllowed]`@RolesAllowed` annotation are mapped to group names in the `groups` claim of the JWT, which results in an authorization decision wherever the security constraint is applied.
 
-The [hotspot=RolesAllowed]`@RolesAllowed({"admin", "user"})` annotation allows only authenticated users with the role of `admin` or `user` to access the `system` service.
+The [hotspot=RolesAllowed]`@RolesAllowed` annotation allows only authenticated users with the role of `admin` or `user` to access the `system` service.
 Therefore, this service is properly secured.
 
 // =================================================================================================
@@ -169,7 +169,7 @@ Therefore, this service is properly secured.
 `backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java`
 ----
 [role="edit_command_text"]
-Add the [hotspot=RolesAllowed hotspot=RolesAllowed2]`@RolesAllowed({"admin", "user"})` annotation.
+Add the [hotspot=RolesAllowed hotspot=RolesAllowed2]`@RolesAllowed` annotations.
 
 InventoryResource.java
 [source, java, linenums, role='code_column']
@@ -236,7 +236,7 @@ MicroProfile maps the JWT claims to JAX-RS security-related methods and makes th
 The [hotspot=getJwtUsername]`getJwtUsername()` function retrieves the user name from the injected [hotspot=JsonWebToken]`JsonWebToken jwtPrincipal` token by calling the [hotspot=getName]`getName()` method.
 
 The [hotspot=getJwtGroups]`getJwtGroups()` function retrieves the user groups information from the JSON Web Token.
-The [hotspot=securityContext]`SecurityContext.getUserPrincipal()` method returns an object of the [hotspot=javaSecurity]`java.security.Principal` type. This object is also an instance of the [hotspot=JsonWebToken]`org.eclipse.microprofile.jwt.JsonWebToken` type, which has the [hotspot=groups]`getGroups()` method.
+The [hotspot=securityContext]`SecurityContext.getUserPrincipal()` method returns an object of the [hotspot=javaSecurity]`java.security.Principal` type. This object is also an instance of the [hotspot=JsonWebTokenImport]`org.eclipse.microprofile.jwt.JsonWebToken` type, which has the [hotspot=groups]`getGroups()` method.
 
 The [hotspot=getCustomClaim]`getCustomClaim()` function retrieves the custom claim from the token if the authenticated user has the `admin` role. Otherwise, it returns a [hotspot=responseStatus]`Status.FORBIDDEN` message.
 The [hotspot=isUserInRole]`SecurityContext.isUserInRole(String)` method returns a `true` value for any role that appears in the MicroProfile JWT `groups` claim because role names are mapped to group names in the claim.
@@ -291,7 +291,7 @@ SystemEndpointTest.java
 include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java[]
 ----
 
-[role="code_command hotspot" subs="quotes"]
+[role="code_command hotspot file=1" subs="quotes"]
 ----
 #Create the `InventoryEndpointTest` class.#
 `backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java`

--- a/README.adoc
+++ b/README.adoc
@@ -146,7 +146,7 @@ The [hotspot=mpJwtTag]`<mpJwt/>` element is required to configure the injection 
 Add the [hotspot=RolesAllowed]`@RolesAllowed` annotation.
 
 SystemResource.java
-[source, java, linenums, role='code_column']
+[source, java, linenums, role='code_column hide_tags=Copyright']
 ----
 include::finish/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java[]
 ----
@@ -172,7 +172,7 @@ Therefore, this service is properly secured.
 Add the [hotspot=RolesAllowed hotspot=RolesAllowed2]`@RolesAllowed` annotations.
 
 InventoryResource.java
-[source, java, linenums, role='code_column']
+[source, java, linenums, role='code_column hide_tags=Copyright']
 ----
 include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java[]
 ----
@@ -200,7 +200,7 @@ However, after you secure the system service with token-based authentication, yo
 ----
 
 SecureSystemClient.java
-[source, java, linenums, role='code_column']
+[source, java, linenums, role='code_column hide_tags=Copyright']
 ----
 include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/client/SecureSystemClient.java[]
 ----
@@ -226,7 +226,7 @@ To demonstrate how MicroProfile JWT retrieves confidential information and valid
 ----
 
 JwtResource.java
-[source, java, linenums, role='code_column']
+[source, java, linenums, role='code_column hide_tags=Copyright']
 ----
 include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java[]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -297,7 +297,7 @@ include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/Syste
 `backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java`
 ----
 InventoryEndpointTest.java
-[source, java, linenums, role='code_column']
+[source, java, linenums, role='code_column hide_tags=copyright']
 ----
 include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java[]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -317,7 +317,7 @@ After each test confirms that the response code is correct, each test gets the c
 ----
 
 JwtTest.java
-[source, java, linenums, role='code_column']
+[source, java, linenums, role='code_column hide_tags=copyright']
 ----
 include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java[]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -105,8 +105,6 @@ The MicroProfile JWT feature, [hotspot=mpJwt]`mpJwt`, has been added as a depend
 // Creating the server configuration file
 // =================================================================================================
 
-=== Creating the server configuration file
-
 [role="code_command hotspot", subs="quotes"]
 ----
 #Create the server configuration file.#

--- a/README.adoc
+++ b/README.adoc
@@ -93,13 +93,13 @@ mvn liberty:stop-server
 pom.xml
 [source, xml, linenums, role='code_column']
 ----
-include::finish/backendServices/pom.xml[tags=**]
+include::finish/backendServices/pom.xml[]
 ----
 
 
 Navigate to the `start` directory.
 
-The MicroProfile JWT feature, [hotspot=23]`mpJwt`, has been added as a dependency in your [hotspot]`pom.xml` file.
+The MicroProfile JWT feature, [hotspot=mpJwt]`mpJwt`, has been added as a dependency in your [hotspot]`pom.xml` file.
 
 // =================================================================================================
 // Creating the server configuration file
@@ -116,17 +116,17 @@ The MicroProfile JWT feature, [hotspot=23]`mpJwt`, has been added as a dependenc
 server.xml
 [source, xml, linenums, role='code_column']
 ----
-include::finish/backendServices/src/main/liberty/config/server.xml[tags=jwt]
+include::finish/backendServices/src/main/liberty/config/server.xml[]
 ----
 
-The [hotspot=3]`mpJwt` feature adds the libraries that are required for MicroProfile JWT implementation.
+The [hotspot=mpJwt]`mpJwt` feature adds the libraries that are required for MicroProfile JWT implementation.
 
-The [hotspot=25-26]`<mpJwt/>` element is required to configure the injection of the caller's JWT.
+The [hotspot=mpJwtTag]`<mpJwt/>` element is required to configure the injection of the caller's JWT.
 
 |===
-| [hotspot=25]`keyName` | Specifies the key alias name to locate the public key for JWT signature validation and must be in the keystore in the SSL configuration.
-| [hotspot=25]`audiences` | Identifies the recipients and must match the `aud` claim in the JWT.
-| [hotspot=26]`issuer` | Issues security tokens and must match the `iss` claim in the JWT.
+| [hotspot=mpJwtTag]`keyName` | Specifies the key alias name to locate the public key for JWT signature validation and must be in the keystore in the SSL configuration.
+| [hotspot=mpJwtTag]`audiences` | Identifies the recipients and must match the `aud` claim in the JWT.
+| [hotspot=mpJwtTag]`issuer` | Issues security tokens and must match the `iss` claim in the JWT.
 |===
 
 
@@ -139,11 +139,11 @@ The [hotspot=25-26]`<mpJwt/>` element is required to configure the injection of 
 
 [role="code_command hotspot", subs="quotes"]
 ----
-#Update the `SystemResource` class#
+#Update the `SystemResource` class.#
 `backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java`
 ----
 [role="edit_command_text"]
-Add the [hotspot=RolesAllowed]`@RolesAllowed` line.
+Add the [hotspot=RolesAllowed]`@RolesAllowed({"admin", "user"})` annotation.
 
 SystemResource.java
 [source, java, linenums, role='code_column']
@@ -152,7 +152,7 @@ include::finish/backendServices/src/main/java/io/openliberty/guides/system/Syste
 ----
 
 You have just added roles-based access control to the `SystemResource` class.
-Role names that are used in the [hotspot=15]`@RolesAllowed` annotation are mapped to group names in the `groups` claim of the JWT, which results in an authorization decision wherever the security constraint is applied.
+Role names that are used in the [hotspot=RolesAllowed]`@RolesAllowed` annotation are mapped to group names in the `groups` claim of the JWT, which results in an authorization decision wherever the security constraint is applied.
 
 The [hotspot=RolesAllowed]`@RolesAllowed({"admin", "user"})` annotation allows only authenticated users with the role of `admin` or `user` to access the `system` service.
 Therefore, this service is properly secured.
@@ -162,24 +162,27 @@ Therefore, this service is properly secured.
 // =================================================================================================
 
 === Securing the inventory service
+
 [role="code_command hotspot", subs="quotes"]
 ----
-#Replace the `InventoryResource` class.#
+#Update the `InventoryResource` class.#
 `backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java`
 ----
+[role="edit_command_text"]
+Add the [hotspot=RolesAllowed hotspot=RolesAllowed2]`@RolesAllowed({"admin", "user"})` annotation.
 
 InventoryResource.java
 [source, java, linenums, role='code_column']
 ----
-include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java[tags=jwt;!copyright]
+include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java[]
 ----
 
 You have just added roles-based access control to the `InventoryResource` class.
-Similarly, for each specific service, the [hotspot=25 hotspot=49]`@RolesAllowed` annotation sets which roles are allowed to access it. Therefore, the inventory service is properly secured, as well.
+Similarly, for each specific service, the [hotspot=RolesAllowed hotspot=RolesAllowed2]`@RolesAllowed` annotation sets which roles are allowed to access it. Therefore, the inventory service is properly secured, as well.
 
-In addition, the [hotspot=28-46]`getPropertiesForHost()` method gets the HTTP Authorization header, which contains the corresponding security token, from the HTTP request caller. The method uses this authorization header to retrieve information from the `system` service.
+In addition, the [hotspot=getPropertiesForHost]`getPropertiesForHost()` method gets the HTTP Authorization header, which contains the corresponding security token, from the HTTP request caller. The method uses this authorization header to retrieve information from the `system` service.
 
-The final addition of the [hotspot=33]`manager.get(hostname, authHeader)` code adds the authentication header to the client that sends the HTTP `GET` request to the `system` service.
+The final addition of the [hotspot=managerGet]`manager.get(hostname, authHeader)` code adds the authentication header to the client that sends the HTTP `GET` request to the `system` service.
 
 // =================================================================================================
 // Adding the SecureSystemClient class
@@ -199,13 +202,13 @@ However, after you secure the system service with token-based authentication, yo
 SecureSystemClient.java
 [source, java, linenums, role='code_column']
 ----
-include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/client/SecureSystemClient.java[tags=jwt;!copyright]
+include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/client/SecureSystemClient.java[]
 ----
 
-The [hotspot=10-33]`SecureSystemClient` class inherits methods from the [hotspot=10]`SystemClient` class. These methods hand 
+The [hotspot=SecureSystemClient]`SecureSystemClient` class inherits methods from the [hotspot=SystemClient]`SystemClient` class. These methods hand 
 the HTTP `GET` request to the system service to retrieve system properties. However, the `SecureSystemClient` 
-class overrides the [hotspot=22-25]`buildClientBuilder()` method by adding the authorization header to the returned 
-builder, [hotspot=24]`return builder.header(HttpHeaders.AUTHORIZATION, authHeader)`. By adding the authorization 
+class overrides the [hotspot=buildClientBuilder]`buildClientBuilder()` method by adding the authorization header to the returned 
+builder, [hotspot=return]`return builder.header(HttpHeaders.AUTHORIZATION, authHeader)`. By adding the authorization 
 header to the client request, the `SecureSystemClient` class can access services that are secured.
 
 // =================================================================================================
@@ -225,19 +228,19 @@ To demonstrate how MicroProfile JWT retrieves confidential information and valid
 JwtResource.java
 [source, java, linenums, role='code_column']
 ----
-include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java[tags=jwt;!copyright]
+include::finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java[]
 ----
 
 MicroProfile maps the JWT claims to JAX-RS security-related methods and makes the set of claims available through getters.
 
-The [hotspot=27-29]`getJwtUsername()` function retrieves the user name from the injected [hotspot=22]`JsonWebToken jwtPrincipal` token by calling the [hotspot=28]`getName()` method.
+The [hotspot=getJwtUsername]`getJwtUsername()` function retrieves the user name from the injected [hotspot=JsonWebToken]`JsonWebToken jwtPrincipal` token by calling the [hotspot=getName]`getName()` method.
 
-The [hotspot=34-42]`getJwtGroups()` function retrieves the user groups information from the JSON Web Token.
-The [hotspot=36]`SecurityContext.getUserPrincipal()` method returns an object of the [hotspot=13]`java.security.Principal` type. This object is also an instance of the [hotspot=10]`org.eclipse.microprofile.jwt.JsonWebToken` type, which has the [hotspot=39]`getGroups()` method.
+The [hotspot=getJwtGroups]`getJwtGroups()` function retrieves the user groups information from the JSON Web Token.
+The [hotspot=securityContext]`SecurityContext.getUserPrincipal()` method returns an object of the [hotspot=javaSecurity]`java.security.Principal` type. This object is also an instance of the [hotspot=JsonWebToken]`org.eclipse.microprofile.jwt.JsonWebToken` type, which has the [hotspot=groups]`getGroups()` method.
 
-The [hotspot=47-53]`getCustomClaim()` function retrieves the custom claim from the token if the authenticated user has the `admin` role. Otherwise, it returns a [hotspot=52]`Status.FORBIDDEN` message.
-The [hotspot=48]`SecurityContext.isUserInRole(String)` method returns a `true` value for any role that appears in the MicroProfile JWT `groups` claim because role names are mapped to group names in the claim.
-The [hotspot=49]`jwtPrincipal.getClaim("customClaim")` method retrieves the value of the custom claim by its name. This method is useful when you want to validate information about a custom claim from the security token.
+The [hotspot=getCustomClaim]`getCustomClaim()` function retrieves the custom claim from the token if the authenticated user has the `admin` role. Otherwise, it returns a [hotspot=responseStatus]`Status.FORBIDDEN` message.
+The [hotspot=isUserInRole]`SecurityContext.isUserInRole(String)` method returns a `true` value for any role that appears in the MicroProfile JWT `groups` claim because role names are mapped to group names in the claim.
+The [hotspot=customClaim]`jwtPrincipal.getClaim("customClaim")` method retrieves the value of the custom claim by its name. This method is useful when you want to validate information about a custom claim from the security token.
 
 // =================================================================================================
 // Building and running the application
@@ -285,7 +288,7 @@ Write `SystemEndpointTest`, `InventoryEndpointTest`, and `JwtTest` classes to te
 SystemEndpointTest.java
 [source, java, linenums, role='code_column']
 ----
-include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java[tags=test]
+include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java[]
 ----
 
 [role="code_command hotspot" subs="quotes"]
@@ -296,18 +299,18 @@ include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/Syste
 InventoryEndpointTest.java
 [source, java, linenums, role='code_column']
 ----
-include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java[tags=test]
+include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java[]
 ----
 
-In the [hotspot=24-26 file=0]`setup()` step before test cases, an authorization header is created with the credentials of a test user who has the `TESTUSER` name and the `admin` role.
+In the [hotspot=setup file=0]`setup()` step before test cases, an authorization header is created with the credentials of a test user who has the `TESTUSER` name and the `admin` role.
 This authorization header is added when the test client sends an HTTP `GET` request to a secure service to retrieve information.
 
-Each test case tries to first assert that with a valid authorization header, it can get a [hotspot=39-40 file=1]`Status.OK` code from the response.
+Each test case tries to first assert that with a valid authorization header, it can get a [hotspot=statusOK file=1]`Status.OK` code from the response.
 The test fails if the response returns a `Status.FORBIDDEN` message, which means the authorization header is invalid.
 
 After each test confirms that the response code is correct, each test gets the content from the designated endpoint and compares the result with its expected value.
 
-[role="code_command hotspot"  subs="quotes"]
+[role="code_command hotspot file=2"  subs="quotes"]
 ----
 #Create the `JwtTest` class.#
 `backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java`
@@ -316,16 +319,16 @@ After each test confirms that the response code is correct, each test gets the c
 JwtTest.java
 [source, java, linenums, role='code_column']
 ----
-include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java[tags=test]
+include::finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java[]
 ----
 
-In the [hotspot=23-25 file=2]`setup()` step of the `JwtTest` class, an authorization header is created with the credentials of a test user who has the `TESTUSER` name and the `user` role.
+In the [hotspot=setup file=2]`setup()` step of the `JwtTest` class, an authorization header is created with the credentials of a test user who has the `TESTUSER` name and the `user` role.
 The authorization header is added when the test client sends an HTTP `GET` request to a secure JWT service.
 
-The [hotspot=33-45 file=2]`testJWTGetName()` test accesses the `\https://localhost:5051/inventory/jwt/username` endpoint to get the username from the JWT token and to verify
+The [hotspot=testJwtGetName file=2]`testJWTGetName()` test accesses the `\https://localhost:5051/inventory/jwt/username` endpoint to get the username from the JWT token and to verify
 whether the username is the same as the `TESTUSER` user name.
 
-The [hotspot=47-54 file=2]`testJWTGetCustomClaim()` test accesses the `\https://localhost:5051/inventory/jwt/customClaim` endpoint. Because this service is secured and only accessible to users who have the `admin` role,
+The [hotspot=testJwtGetCustomClaim file=2]`testJWTGetCustomClaim()` test accesses the `\https://localhost:5051/inventory/jwt/customClaim` endpoint. Because this service is secured and only accessible to users who have the `admin` role,
 the test asserts that the current test user with the `user` role is forbidden from accessing it.
 
 [role='command']
@@ -348,7 +351,7 @@ Results :
 Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
 ----
 
-To see whether the tests detect a failure, remove the authorization header generation in the [hotspot=24-26 file=1]`setup()` method of the [hotspot file=1]`InventoryEndpointTest.java` file.
+To see whether the tests detect a failure, remove the authorization header generation in the [hotspot=setup file=1]`setup()` method of the [hotspot file=1]`InventoryEndpointTest.java` file.
 Rerun the Maven build. You see that a test failure occurs.
 
 // =================================================================================================

--- a/README.adoc
+++ b/README.adoc
@@ -135,6 +135,7 @@ The [hotspot=mpJwtTag]`<mpJwt/>` element is required to configure the injection 
 
 === Securing the system service
 
+
 [role="code_command hotspot", subs="quotes"]
 ----
 #Update the `SystemResource` class.#
@@ -160,6 +161,7 @@ Therefore, this service is properly secured.
 // =================================================================================================
 
 === Securing the inventory service
+
 
 [role="code_command hotspot", subs="quotes"]
 ----

--- a/finish/backendServices/pom.xml
+++ b/finish/backendServices/pom.xml
@@ -20,7 +20,9 @@
         <!-- Open Liberty features -->
         <dependency>
             <groupId>io.openliberty.features</groupId>
+            <!-- tag::mpJwt[] -->
             <artifactId>mpJwt-1.1</artifactId>
+            <!-- end::mpJwt[] -->
             <type>esa</type>
         </dependency>
         <dependency>

--- a/finish/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -35,15 +35,20 @@ public class InventoryResource {
   InventoryManager manager;
 
   @GET
+  // tag::RolesAllowed[]
   @RolesAllowed({ "admin", "user" })
+  // end::RolesAllowed[]
   @Path("{hostname}")
   @Produces(MediaType.APPLICATION_JSON)
+  // tag::getPropertiesForHost[]
   public Response getPropertiesForHost(@PathParam("hostname") String hostname,
       @Context HttpHeaders httpHeaders) {
     String authHeader = httpHeaders.getRequestHeaders()
                                    .getFirst(HttpHeaders.AUTHORIZATION);
     // Get properties
+    // tag::managerGet[]
     Properties props = manager.get(hostname, authHeader);
+    // end::managerGet[]
     if (props == null) {
       return Response.status(Response.Status.NOT_FOUND)
                      .entity(
@@ -57,9 +62,12 @@ public class InventoryResource {
     manager.add(hostname, props);
     return Response.ok(props).build();
   }
+  // end::getPropertiesForHost[]
 
   @GET
+  // tag::RolesAllowed2[]
   @RolesAllowed({ "admin" })
+  // end::RolesAllowed2[]
   @Produces(MediaType.APPLICATION_JSON)
   public InventoryList listContents() {
     return manager.list();

--- a/finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java
@@ -20,10 +20,14 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Context;
+// tag::JsonWebToken[]
 import org.eclipse.microprofile.jwt.JsonWebToken;
+// end::JsonWebToken[]
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.core.SecurityContext;
+// tag::javaSecurity[]
 import java.security.Principal;
+// end::javaSecurity[]
 
 @RequestScoped
 @Path("jwt")
@@ -32,37 +36,57 @@ public class JwtResource {
   // JWT will be injected for each JAX-RS request. The injection is performed by
   // the mpJwt-1.0 feature.
   @Inject
+  // tag::JsonWebToken[]
   private JsonWebToken jwtPrincipal;
+  // end::JsonWebToken[]
 
   @GET
   @RolesAllowed({ "admin", "user" })
   @Path("/username")
+  // tag::getJwtUsername[]
   public Response getJwtUsername() {
+    // tag::getName[]
     return Response.ok(this.jwtPrincipal.getName()).build();
+    // end::getName[]
   }
+  // end::getJwtUsername[]
 
   @GET
   @RolesAllowed({ "admin", "user" })
   @Path("/groups")
+  // tag::getJwtGroups[]
   public Response getJwtGroups(@Context SecurityContext securityContext) {
     Set<String> groups = null;
+    // tag::securityContext[]
     Principal user = securityContext.getUserPrincipal();
+    // end::securityContext[]
     if (user instanceof JsonWebToken) {
       JsonWebToken jwt = (JsonWebToken) user;
+      // tag::groups[]
       groups = jwt.getGroups();
+      // end::groups[]
     }
     return Response.ok(groups.toString()).build();
   }
+  // end::getJwtGroups[]
 
   @GET
   @RolesAllowed({ "admin", "user" })
   @Path("/customClaim")
+  // tag::getCustomClaim[]
   public Response getCustomClaim(@Context SecurityContext securityContext) {
+    // tag::isUserInRole[]
     if (securityContext.isUserInRole("admin")) {
+    // end::isUserInRole[]
+      // tag::customClaim[]
       String customClaim = jwtPrincipal.getClaim("customClaim");
+      // end::customClaim[]
       return Response.ok(customClaim).build();
     }
+    // tag::responseStatus[]
     return Response.status(Response.Status.FORBIDDEN).build();
+    // end::responseStatus[]
   }
+  // end::getCustomClaim[]
 }
 // end::jwt[]

--- a/finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/inventory/JwtResource.java
@@ -20,9 +20,9 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Context;
-// tag::JsonWebToken[]
+// tag::JsonWebTokenImport[]
 import org.eclipse.microprofile.jwt.JsonWebToken;
-// end::JsonWebToken[]
+// end::JsonWebTokenImport[]
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.core.SecurityContext;
 // tag::javaSecurity[]

--- a/finish/backendServices/src/main/java/io/openliberty/guides/inventory/client/SecureSystemClient.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/inventory/client/SecureSystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/main/java/io/openliberty/guides/inventory/client/SecureSystemClient.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/inventory/client/SecureSystemClient.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/main/java/io/openliberty/guides/inventory/client/SecureSystemClient.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/inventory/client/SecureSystemClient.java
@@ -20,7 +20,10 @@ import java.util.Properties;
 import io.openliberty.guides.inventory.client.SystemClient;
 
 @RequestScoped
+// tag::SecureSystemClient[]
+// tag::SystemClient[]
 public class SecureSystemClient extends SystemClient {
+// end::SystemClient[]  
 
   // Constants for building URI to the system service.
   private final int DEFAULT_SEC_PORT = Integer.valueOf(
@@ -32,10 +35,14 @@ public class SecureSystemClient extends SystemClient {
     return super.buildUrl(protocol, host, port, path);
   }
 
+  // tag::buildClientBuilder[]
   public Builder buildClientBuilder(String url, String authHeader) {
     Builder builder = super.buildClientBuilder(url);
+    // tag::return[]
     return builder.header(HttpHeaders.AUTHORIZATION, authHeader);
+    // end::return[]
   }
+  // end::buildClientBuilder[]
 
   public Properties getProperties(String hostname, String authHeader) {
     String url = buildUrl(SECURED_PROTOCOL, hostname, 
@@ -44,4 +51,5 @@ public class SecureSystemClient extends SystemClient {
     return getPropertiesHelper(clientBuilder);
   }
 }
+// end::SecureSystemClient[]
 // end::jwt[]

--- a/finish/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/finish/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -25,7 +25,9 @@ import javax.annotation.security.RolesAllowed;
 @Path("properties")
 public class SystemResource {
   @GET
+  // tag::RolesAllowed[]
   @RolesAllowed({ "admin", "user" })
+  // end::RolesAllowed[]
   @Produces(MediaType.APPLICATION_JSON)
   public Properties getProperties() {
     return System.getProperties();

--- a/finish/backendServices/src/main/liberty/config/server.xml
+++ b/finish/backendServices/src/main/liberty/config/server.xml
@@ -1,5 +1,5 @@
 <!-- tag::copyright[] -->
-<!-- Copyright (c) 2018 IBM Corporation and others.
+<!-- Copyright (c) 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/finish/backendServices/src/main/liberty/config/server.xml
+++ b/finish/backendServices/src/main/liberty/config/server.xml
@@ -1,3 +1,4 @@
+<!-- tag::copyright[] -->
 <!-- Copyright (c) 2018 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -7,6 +8,7 @@
     Contributors:
     IBM Corporation - initial API and implementation
 -->
+<!-- end::copyright[] -->
 <!-- tag::jwt[] -->
 <server description="Backend server">
     <featureManager>

--- a/finish/backendServices/src/main/liberty/config/server.xml
+++ b/finish/backendServices/src/main/liberty/config/server.xml
@@ -1,5 +1,5 @@
 <!-- tag::copyright[] -->
-<!-- Copyright (c) 2019 IBM Corporation and others.
+<!-- Copyright (c) 2018, 2019 IBM Corporation and others.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at

--- a/finish/backendServices/src/main/liberty/config/server.xml
+++ b/finish/backendServices/src/main/liberty/config/server.xml
@@ -10,7 +10,9 @@
 <!-- tag::jwt[] -->
 <server description="Backend server">
     <featureManager>
+        <!-- tag::mpJwt[] -->
         <feature>mpJwt-1.1</feature>
+        <!-- end::mpJwt[] -->
         <feature>ssl-1.0</feature>
         <feature>jaxrs-2.1</feature>
         <feature>jsonp-1.1</feature>
@@ -32,7 +34,9 @@
 
     <!-- The MP JWT configuration that injects the caller's JWT into a 
          ResourceScoped bean for inspection. -->
+    <!-- tag::mpJwtTag[] -->     
     <mpJwt id="jwtUserConsumer" keyName="default" audiences="simpleapp" 
            issuer="${jwt.issuer}"/>
+    <!-- end::mpJwtTag[] -->   
 </server>
 <!-- end::jwt[] -->

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/InventoryEndpointTest.java
@@ -34,9 +34,11 @@ public class InventoryEndpointTest {
   String authHeader;
 
   @Before
+  // tag::setup[]
   public void setup() throws Exception {
     authHeader = "Bearer " + new JwtVerifier().createAdminJwt(TESTNAME);
   }
+  // end::setup[]
 
   @Test
   public void testSuite() {
@@ -49,8 +51,10 @@ public class InventoryEndpointTest {
     Response invResponse = TestUtils.processRequest(invUrl, "GET", null, authHeader);
 
     assertEquals(
+      // tag::statusOK[]
         "HTTP response code should have been " + Status.OK.getStatusCode() + ".",
         Status.OK.getStatusCode(), invResponse.getStatus());
+      // end::statusOK[]
 
     JsonObject responseJson = TestUtils.toJsonObj(
         invResponse.readEntity(String.class));

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/JwtTest.java
@@ -33,9 +33,11 @@ public class JwtTest {
   String authHeader;
 
   @Before
+  // tag::setup[]
   public void setup() throws Exception {
     authHeader = "Bearer " + new JwtVerifier().createUserJwt(TESTNAME);
   }
+  // end::setup[]
 
   @Test
   public void testSuite() {
@@ -43,6 +45,7 @@ public class JwtTest {
     this.testJwtGetCustomClaim();
   }
 
+  // tag::testJwtGetName[]
   public void testJwtGetName() {
     String jwtUrl = baseUrl + INV_JWT + "/username";
     Response jwtResponse = TestUtils.processRequest(jwtUrl, "GET", null, authHeader);
@@ -56,7 +59,9 @@ public class JwtTest {
     assertEquals("The test name and jwt token name should match", TESTNAME,
         responseName);
   }
+  // end::testJwtGetName[]
 
+  // tag::testJwtGetCustomClaim[]
   public void testJwtGetCustomClaim() {
     String jwtUrl = baseUrl + INV_JWT + "/customClaim";
     Response jwtResponse = TestUtils.processRequest(jwtUrl, "GET", null, authHeader);
@@ -65,6 +70,7 @@ public class JwtTest {
         + Status.FORBIDDEN.getStatusCode() + ".", Status.FORBIDDEN.getStatusCode(),
         jwtResponse.getStatus());
   }
+  // end::testJwtGetCustomClaim[]
 
 }
 // end::test[]

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java
@@ -36,9 +36,9 @@ public class SystemEndpointTest {
   @Before
   // tag::setup[]
   public void setup() throws Exception {
-  // end::setup[]
     authHeader = "Bearer " + new JwtVerifier().createAdminJwt(TESTNAME);
   }
+  // end::setup[]
 
   @Test
   public void testSuite() {

--- a/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java
+++ b/finish/backendServices/src/test/java/it/io/openliberty/guides/jwt/SystemEndpointTest.java
@@ -34,7 +34,9 @@ public class SystemEndpointTest {
   String authHeader;
 
   @Before
+  // tag::setup[]
   public void setup() throws Exception {
+  // end::setup[]
     authHeader = "Bearer " + new JwtVerifier().createAdminJwt(TESTNAME);
   }
 

--- a/start/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/start/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2018 IBM Corporation and others.
+ * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/start/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
+++ b/start/backendServices/src/main/java/io/openliberty/guides/inventory/InventoryResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2019 IBM Corporation and others.
+ * Copyright (c) 2018, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -35,6 +35,7 @@ public class InventoryResource {
   InventoryManager manager;
 
   @GET
+  //Add the @RolesAllowed({ "admin", "user" }) annotation here.
   @Path("{hostname}")
   @Produces(MediaType.APPLICATION_JSON)
   public Response getPropertiesForHost(@PathParam("hostname") String hostname,
@@ -56,6 +57,7 @@ public class InventoryResource {
   }
 
   @GET
+  //Add the @RolesAllowed({ "admin" }) annotation here.
   @Produces(MediaType.APPLICATION_JSON)
   public InventoryList listContents() {
     return manager.list();

--- a/start/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/start/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -1,6 +1,6 @@
 // tag::copyright[]
 /*******************************************************************************
- * Copyright (c) 2017, 2018 IBM Corporation and others.
+ * Copyright (c) 2017, 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/start/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java
+++ b/start/backendServices/src/main/java/io/openliberty/guides/system/SystemResource.java
@@ -25,6 +25,7 @@ import javax.annotation.security.RolesAllowed;
 @Path("properties")
 public class SystemResource {
   @GET
+  //Add the @RolesAllowed({ "admin", "user" }) annotation here.
   @Produces(MediaType.APPLICATION_JSON)
   public Properties getProperties() {
     return System.getProperties();


### PR DESCRIPTION
#77 

Design Choices:
- The `@RolesAllowed` hotspots were used without the parameters since the parameters change. i.e. `@RolesAllowed({ "admin", "user" })` vs. `@RolesAllowed({ "admin" })`.
- The table with hotspots to the different attributes of the `<mpJwt/>` all link to the same end tag vs. the line number it is in due to the fact that comments can't exist inside tags in xml files.
- Instead of `replacing` the code in the two files mentioned, I changed it to `update` as the comments further in the guide comments on the change.
- Hotspots were updated to the unique tag model vs. line tagging.

Branch was uploaded to the lgdev site for quick review.