### PR TITLE
Provide specific instruction for the cloud-hosted guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -402,7 +402,6 @@ endif::[]
 
 // Following context for the cloud-hosted guide:
 ifdef::cloud-hosted[]
-In your browser, go to the front-end web application endpoint at http://localhost:9090/login.jsf. Log in with one of the following usernames and its corresponding password:
 To launch the front-end web application, 
 select **Launch Application** from the menu of the IDE, provide the port number **9090**, 
 and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL. 

--- a/README.adoc
+++ b/README.adoc
@@ -110,9 +110,24 @@ After you see the following message in both command-line sessions, both of your 
 The defaultServer server is ready to run a smarter planet.
 ----
 
+// Following context for the static guide:
+ifndef::cloud-hosted[]
 In your browser, go to the front-end web application endpoint at
 http://localhost:9090/login.jsf[http://localhost:9090/login.jsf^]. From here,
 you can log in to the application with the form-based login.
+endif::[]
+
+// Following context for the cloud-hosted guide:
+ifdef::cloud-hosted[]
+To launch the front-end web application, 
+select **Launch Application** from the menu of the IDE, provide the port number **9090**, 
+and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL. 
+
+In your browser, go to the front-end web application endpoint at the
+**https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/login.jsf** URL. 
+From here, you can log in to the application with the form-based login.
+endif::[]
+
 
 Log in with one of the following usernames and its corresponding password:
 
@@ -134,11 +149,28 @@ have sufficient privileges to view current OS information.
 Additionally, the `groups` claim of the JWT is read by the `system` service and
 requested by the front end to be displayed.
 
+// Following context for the static guide:
+ifndef::cloud-hosted[]
 You can try accessing these services without a JWT by going to the
 https://localhost:8443/system/properties/os[https://localhost:8443/system/properties/os^]
 `system` endpoint in your browser. You get a blank screen and aren't given
 access because you didn't supply a valid JWT with the request. The following
 error also appears in the command-line session of the `system` service:
+endif::[]
+
+// Following context for the cloud-hosted guide:
+ifdef::cloud-hosted[]
+You can try accessing these services without a JWT by going to the **system** endpoint. 
+Run the following curl command at a terminal:
+```
+curl -k https://localhost:8443/system/properties/os
+```
+{: codeblock}
+
+You get a blank screen and aren't given
+access because you didn't supply a valid JWT with the request. The following
+error also appears in the command-line session of the **system** service:
+endif::[]
 
 [source, role="no_copy"]
 ----
@@ -363,7 +395,22 @@ The [hotspot=mpJwt file=1]`mpJwt` feature adds the libraries that are required f
 
 Because you are running the `frontend` and `system` services in dev mode, the changes that you made were automatically picked up. You're now ready to check out your application in your browser.
 
+// Following context for the static guide:
+ifndef::cloud-hosted[]
 In your browser, go to the front-end web application endpoint at http://localhost:9090/login.jsf. Log in with one of the following usernames and its corresponding password:
+endif::[]
+
+// Following context for the cloud-hosted guide:
+ifdef::cloud-hosted[]
+In your browser, go to the front-end web application endpoint at http://localhost:9090/login.jsf. Log in with one of the following usernames and its corresponding password:
+To launch the front-end web application, 
+select **Launch Application** from the menu of the IDE, provide the port number **9090**, 
+and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL. 
+
+In your browser, go to the front-end web application endpoint at the
+**https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/login.jsf** URL. 
+Log in with one of the following usernames and its corresponding password:
+endif::[]
 
 [cols="<35, ^200, ^200"]
 |===
@@ -381,9 +428,23 @@ You can also see the value of the `groups` claim in the row with the `Roles:` la
 These roles are read from the JWT and sent back to the front end to
 be displayed.
 
+// Following context for the static guide:
+ifndef::cloud-hosted[]
 You can check that the `system` service is secured against unauthenticated
 requests by going to the https://localhost:8443/system/properties/os[https://localhost:8443/system/properties/os^]
 `system` endpoint in your browser.
+endif::[]
+
+// Following context for the cloud-hosted guide:
+ifdef::cloud-hosted[]
+You can check that the **system** service is secured against unauthenticated
+requests by going to the **system** endpoint. 
+Run the following curl command at a terminal:
+```
+curl -k https://localhost:8443/system/properties/os
+```
+{: codeblock}
+endif::[]
 
 In the front end, you see your JWT displayed in the row with the `JSON Web Token` label.
 

--- a/README.adoc
+++ b/README.adoc
@@ -120,7 +120,7 @@ endif::[]
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
 To launch the front-end web application, 
-select **Launch Application** from the menu of the IDE, provide the port number **9090**, 
+select **Launch Application** from the menu of the IDE, type in **9090** to specify the port number for the front-end web application, 
 and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL, 
 where **yourname** is your user name.
 
@@ -404,7 +404,7 @@ endif::[]
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
 To launch the front-end web application, 
-select **Launch Application** from the menu of the IDE, provide the port number **9090**, 
+select **Launch Application** from the menu of the IDE, type in **9090** to specify the port number for the front-end web application, 
 and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL, 
 where **yourname** is your user name.
 

--- a/README.adoc
+++ b/README.adoc
@@ -121,7 +121,8 @@ endif::[]
 ifdef::cloud-hosted[]
 To launch the front-end web application, 
 select **Launch Application** from the menu of the IDE, provide the port number **9090**, 
-and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL. 
+and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL, 
+where **yourname** is your user name.
 
 In your browser, go to the front-end web application endpoint at the
 **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/login.jsf** URL. 
@@ -404,7 +405,8 @@ endif::[]
 ifdef::cloud-hosted[]
 To launch the front-end web application, 
 select **Launch Application** from the menu of the IDE, provide the port number **9090**, 
-and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL. 
+and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL, 
+where **yourname** is your user name.
 
 In your browser, go to the front-end web application endpoint at the
 **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/login.jsf** URL. 

--- a/README.adoc
+++ b/README.adoc
@@ -110,14 +110,14 @@ After you see the following message in both command-line sessions, both of your 
 The defaultServer server is ready to run a smarter planet.
 ----
 
-// Following context for the static guide:
+// static guide instructions:
 ifndef::cloud-hosted[]
 In your browser, go to the front-end web application endpoint at
 http://localhost:9090/login.jsf[http://localhost:9090/login.jsf^]. From here,
 you can log in to the application with the form-based login.
 endif::[]
 
-// Following context for the cloud-hosted guide:
+// cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
 To launch the front-end web application, 
 select **Launch Application** from the menu of the IDE, provide the port number **9090**, 
@@ -150,7 +150,7 @@ have sufficient privileges to view current OS information.
 Additionally, the `groups` claim of the JWT is read by the `system` service and
 requested by the front end to be displayed.
 
-// Following context for the static guide:
+// static guide instructions:
 ifndef::cloud-hosted[]
 You can try accessing these services without a JWT by going to the
 https://localhost:8443/system/properties/os[https://localhost:8443/system/properties/os^]
@@ -159,7 +159,7 @@ access because you didn't supply a valid JWT with the request. The following
 error also appears in the command-line session of the `system` service:
 endif::[]
 
-// Following context for the cloud-hosted guide:
+// cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
 You can try accessing these services without a JWT by going to the **system** endpoint. 
 Run the following curl command at a terminal:
@@ -396,12 +396,12 @@ The [hotspot=mpJwt file=1]`mpJwt` feature adds the libraries that are required f
 
 Because you are running the `frontend` and `system` services in dev mode, the changes that you made were automatically picked up. You're now ready to check out your application in your browser.
 
-// Following context for the static guide:
+// static guide instructions:
 ifndef::cloud-hosted[]
 In your browser, go to the front-end web application endpoint at http://localhost:9090/login.jsf. Log in with one of the following usernames and its corresponding password:
 endif::[]
 
-// Following context for the cloud-hosted guide:
+// cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
 To launch the front-end web application, 
 select **Launch Application** from the menu of the IDE, provide the port number **9090**, 
@@ -429,14 +429,14 @@ You can also see the value of the `groups` claim in the row with the `Roles:` la
 These roles are read from the JWT and sent back to the front end to
 be displayed.
 
-// Following context for the static guide:
+// static guide instructions:
 ifndef::cloud-hosted[]
 You can check that the `system` service is secured against unauthenticated
 requests by going to the https://localhost:8443/system/properties/os[https://localhost:8443/system/properties/os^]
 `system` endpoint in your browser.
 endif::[]
 
-// Following context for the cloud-hosted guide:
+// cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
 You can check that the **system** service is secured against unauthenticated
 requests by going to the **system** endpoint. 

--- a/README.adoc
+++ b/README.adoc
@@ -162,7 +162,7 @@ endif::[]
 // cloud-hosted guide instructions:
 ifdef::cloud-hosted[]
 You can try accessing these services without a JWT by going to the **system** endpoint. 
-Run the following curl command at a terminal:
+Run the following curl command from the terminal in the IDE:
 ```
 curl -k https://localhost:8443/system/properties/os
 ```
@@ -440,7 +440,7 @@ endif::[]
 ifdef::cloud-hosted[]
 You can check that the **system** service is secured against unauthenticated
 requests by going to the **system** endpoint. 
-Run the following curl command at a terminal:
+Run the following curl command from the terminal in the IDE:
 ```
 curl -k https://localhost:8443/system/properties/os
 ```


### PR DESCRIPTION
the cloud-hosted guide cannot run `http://localhost:9090/login.jsp`