### PR TITLE
update cloud-hosted guide instrunctions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -121,11 +121,11 @@ endif::[]
 ifdef::cloud-hosted[]
 To launch the front-end web application, 
 select **Launch Application** from the menu of the IDE, type in **9090** to specify the port number for the front-end web application, 
-and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL, 
-where **yourname** is your user name.
+and click the **OK** button. You’re redirected to the https://accountname-9090.theiadocker-4.proxy.cognitiveclass.ai URL, 
+where **accountname** is your account name.
 
 In your browser, go to the front-end web application endpoint at the
-**https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/login.jsf** URL. 
+https://accountname-9090.theiadocker-4.proxy.cognitiveclass.ai/login.jsf URL. 
 From here, you can log in to the application with the form-based login.
 endif::[]
 
@@ -418,11 +418,11 @@ endif::[]
 ifdef::cloud-hosted[]
 To launch the front-end web application, 
 select **Launch Application** from the menu of the IDE, type in **9090** to specify the port number for the front-end web application, 
-and click the **OK** button. You’re redirected to the **https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/** URL, 
-where **yourname** is your user name.
+and click the **OK** button. You’re redirected to the https://accountname-9090.theiadocker-4.proxy.cognitiveclass.ai URL, 
+where **accountname** is your account name.
 
 In your browser, go to the front-end web application endpoint at the
-**https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/login.jsf** URL. 
+https://accountname-9090.theiadocker-4.proxy.cognitiveclass.ai/login.jsf URL. 
 Log in with one of the following usernames and its corresponding password:
 endif::[]
 


### PR DESCRIPTION
remove the links from https://yourname-9090.theiadocker-4.proxy.cognitiveclass.ai/ 